### PR TITLE
환율 API 주소 업데이트

### DIFF
--- a/commands/exchange.go
+++ b/commands/exchange.go
@@ -37,7 +37,7 @@ USDAUD USDBRL USDCAD USDCHF USDCNY USDEUR USDGBP USDHKD USDINR USDJPY USDKRW USD
 VNDCNY VNDEUR VNDGBP VNDJPY VNDKRW VNDUSD
 `
 
-const api = "https://earthquake.kr:23490/query/" // 참고: https://jaeheon.kr/12
+const api = "https://exchange.jaeheon.kr:23490/query/" // 참고: https://jaeheon.kr/12
 
 func NewExchangeCommand() Command {
 	return &ExchangeCommand{}


### PR DESCRIPTION
[기존 API 주소 지원 종료](https://jaeheon.kr/198?category=818164)로 인해서 환율 봇이 제대로 동작 안 한 것 수정