### PR TITLE
뉴스 메세지 텍스트 수정

### DIFF
--- a/crons/breaking_news.go
+++ b/crons/breaking_news.go
@@ -1,6 +1,7 @@
 package crons
 
 import (
+	"html"
 	"os"
 	"regexp"
 	"strings"
@@ -73,5 +74,5 @@ func (cron *BreakingNewsCron) Execute() string {
 		}
 	}
 
-	return strings.Join(texts, "\n\n")
+	return html.UnescapeString(strings.Join(texts, "\n\n"))
 }

--- a/crons/breaking_news.go
+++ b/crons/breaking_news.go
@@ -66,10 +66,10 @@ func (cron *BreakingNewsCron) Execute() string {
 	}
 
 	var texts []string
-	var linkRegex = regexp.MustCompile(`https://[\s\S]+$`)
+	linkRegex := regexp.MustCompile(`https://[\s\S]+$`)
 	for _, tweet := range tweets {
 		if strings.Contains(tweet.Text, "속보") || strings.Contains(tweet.Text, "1보") {
-			texts = append(texts, linkRegex.ReplaceAllString(tweet.Text, "${1}"))
+			texts = append(texts, linkRegex.ReplaceAllString(tweet.Text, "<${0}>"))
 		}
 	}
 

--- a/crons/breaking_news.go
+++ b/crons/breaking_news.go
@@ -2,6 +2,7 @@ package crons
 
 import (
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/avast/retry-go"
@@ -64,10 +65,11 @@ func (cron *BreakingNewsCron) Execute() string {
 		log.Infof("polled %d tweets, last tweet id: %d", len(tweets), cron.lastTweetID)
 	}
 
-	texts := []string{}
+	var texts []string
+	var linkRegex = regexp.MustCompile(`https://[\s\S]+$`)
 	for _, tweet := range tweets {
 		if strings.Contains(tweet.Text, "속보") || strings.Contains(tweet.Text, "1보") {
-			texts = append(texts, tweet.Text)
+			texts = append(texts, linkRegex.ReplaceAllString(tweet.Text, "${1}"))
 		}
 	}
 


### PR DESCRIPTION
- 뉴스 속보 텍스트 상에서 `https://`로 시작하는 문자열을 `<`와 `>`로 감싸서 discord 상에서 링크 미리보기가 노출되지 않도록 수정하였습니다.
- `&lt;`와 같은 문자열을 `<` 처럼 정상적으로 출력되도록 수정하였습니다. 

ref. https://github.com/webdonalds/discord-bot/issues/48#issuecomment-1065867301
